### PR TITLE
Use req.socket to provide size when available

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+1.0.1 - October 18, 2017
+------------------------
+Support for request size in newer versions of node
+
 1.0.0 - December 22, 2013
 -------------------------
 :sparkles:

--- a/index.js
+++ b/index.js
@@ -118,6 +118,6 @@ exports.token('id', function (req, res) {
  */
 
 exports.token('size', function (req, res) {
-  return parseInt(req._received, 10);
+  return req.socket ? req.socket.bytesRead : parseInt(req._received, 10);
 });
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,4 @@
 
-var bytes = require('bytes');
-
 /**
  * Expose `summary`.
  */

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
   "name": "request-summary",
-  "version": "1.0.0"
+  "version": "1.0.1"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,4 @@
 {
   "name": "request-summary",
-  "version": "1.0.0",
-  "dependencies": {
-    "bytes": "0.2.1"
-  }
+  "version": "1.0.0"
 }


### PR DESCRIPTION
@ivolo similar change to https://github.com/segmentio/response-summary/pull/1, also removed unused dependency on `bytes`